### PR TITLE
final changes to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ module "eks_cluster" {
   cluster_endpoint_public_access_cidrs = ["0.0.0.0/0"]
 
   eks_public_nodegroup_name       = "pht-dev-public-nodegroup"
-  public_nodegroup_ami_type       = "BOTTLEROCKET_ARM_64"
+  public_nodegroup_ami_type       = "AL2_x86_64"
   public_nodegroup_capacity_type  = "ON_DEMAND"
   public_nodegroup_disk_size      = 20
   public_nodegroup_instance_types = ["t3.large"]
@@ -48,7 +48,7 @@ module "eks_cluster" {
   public_nodegroup_max_unavail_pctage = 50
 
   eks_private_nodegroup_name       = "pht-dev-private-nodegroup
-  private_nodegroup_ami_type       = "BOTTLEROCKET_ARM_64"
+  private_nodegroup_ami_type       = "AL2_x86_64"
   private_nodegroup_capacity_type  = "ON_DEMAND"
   private_nodegroup_disk_size      = 20
   private_nodegroup_instance_types = ["t3.large"]
@@ -66,6 +66,7 @@ module "eks_cluster" {
 
 -    This module creates an AWS VPC in which it also creates an EKS cluster with EBS driver, EFS driver EKS     
      addons and a Load Balancer Ingress Controller. 
+     - In this module, both the EBS and EFS driver addons depend on the public and private EKS node groups hence it expects both these node groups to be available before they can be created.
 -    Based on the count of the number of subnets selected by the user, it can conditonally, automatically create  
      these subnets along with their IP addresses using the cidrsubnet() based on the VPC CIDR block selected. 
      -    If the user needs to use the subnet IP addresses of their choice within the VPC CIDR range, then those subnet IP addresses can be manually added in the variables/*.tfvars file in the root module by opting to provide a value of "false" to the auto_create_subnet_addresses argument of the root module.

--- a/ebs-csi-driver-addon.tf
+++ b/ebs-csi-driver-addon.tf
@@ -7,7 +7,7 @@ data "aws_eks_addon_version" "ebs_latest_driver" {
 }
 
 resource "aws_eks_addon" "aws_ebs_csi_driver" {
-  depends_on = [aws_eks_node_group.my_eks_public_nodegroup]
+  depends_on = [aws_eks_node_group.my_eks_public_nodegroup,aws_eks_node_group.my_eks_private_nodegroup]
 
   cluster_name = aws_eks_cluster.my_eks_cluster.id
   addon_name   = "aws-ebs-csi-driver"

--- a/efs-csi-driver-addon.tf
+++ b/efs-csi-driver-addon.tf
@@ -7,8 +7,7 @@ data "aws_eks_addon_version" "efs_latest_driver" {
 }
 
 resource "aws_eks_addon" "aws_efs_csi_driver" {
-  #depends_on = [aws_eks_node_group.my_eks_public_nodegroup]
-  depends_on = [aws_eks_node_group.my_eks_private_nodegroup]
+  depends_on = [aws_eks_node_group.my_eks_public_nodegroup,aws_eks_node_group.my_eks_private_nodegroup]
 
   cluster_name = aws_eks_cluster.my_eks_cluster.id
   addon_name   = "aws-efs-csi-driver"

--- a/lb-controller.tf
+++ b/lb-controller.tf
@@ -52,3 +52,4 @@ resource "helm_release" "lb_controller" {
     }
   ]
 }
+

--- a/locals.tf
+++ b/locals.tf
@@ -33,7 +33,7 @@ locals {
         Name = "efs-sg"
       }
       ingress = {
-        ssh = {
+        nfs = {
           from        = 2049
           to          = 2049
           protocol    = "tcp"


### PR DESCRIPTION
Final changes to the following:

- Changed AMI type from BOTTLEROCKET_ARM_64 to AL2_x86_64 in README.md for both node groups
- Added the requirement of the dependency of the EFS CSI and EBS CSI drivers on public & private node groups
- Added the private node group too in the depends_on arg in ebs-csi-driver-addon.tf file
- Again added the private node group dependency in the efs-csi-driver-addon.tf file
- Removed the additional '}' from the lb-controller.tf file
- Changed the ingress value name from ssh to nfs in the eps-sg security group section in the locals.tf file 